### PR TITLE
Chunk ScanAllAchievements + toc 120005

### DIFF
--- a/DataStore_Achievements/DataStore_Achievements.lua
+++ b/DataStore_Achievements/DataStore_Achievements.lua
@@ -168,6 +168,29 @@ local function ScanSingleAchievement(id, isCompleted, month, day, year, flags, w
 	end
 end
 
+local function ScanCategory(categoryID)
+	local achievementID, achCompleted, month, day, year, flags, wasEarnedByMe, earnedBy, _
+	local prevID
+
+	for i = 1, GetCategoryNumAchievements(categoryID) do
+		achievementID, _, _, achCompleted, month, day, year, _, flags,_, _, _, wasEarnedByMe, earnedBy = GetAchievementInfo(categoryID, i)
+		if achievementID then
+			ScanSingleAchievement(achievementID, achCompleted, month, day, year, flags, wasEarnedByMe)
+
+			-- track previous steps of a progressive achievements
+			prevID = GetPreviousAchievement(achievementID)
+
+			while type(prevID) ~= "nil" do
+				achievementID, _, _, achCompleted, month, day, year, _, flags,_, _, _, wasEarnedByMe, earnedBy = GetAchievementInfo(prevID)
+				if not achievementID then break end	-- exit the loop if id is invalid
+
+				ScanSingleAchievement(achievementID, achCompleted, month, day, year, flags, wasEarnedByMe)
+				prevID = GetPreviousAchievement(achievementID)
+			end
+		end
+	end
+end
+
 local function ScanAllAchievements()
 	-- 2021/06/25 : do not wipe information about fully completed achievements, they will not go "uncompleted" any time soon.
 	-- The reason is that achievements that are both horde and alliance have different id's, and wiping would cancel the achievement
@@ -176,30 +199,25 @@ local function ScanAllAchievements()
 	wipe(thisCharacter.Partial)
 	wipe(thisCharacter.PartialBits)
 
+	-- Run the scan in chunks across frames. Doing it all in one synchronous
+	-- pass exceeds WoW's "script ran too long" budget on 12.0+ (170+ categories
+	-- with progressive achievement chains => tens of thousands of API calls).
 	local cats = GetCategoryList()
-	local prevID
+	local idx = 1
+	local CATEGORIES_PER_FRAME = 15
 
-	local achievementID, achCompleted, month, day, year, flags, wasEarnedByMe, earnedBy, _
-
-	for k, categoryID in ipairs(cats) do
-		for i = 1, GetCategoryNumAchievements(categoryID) do
-			achievementID, _, _, achCompleted, month, day, year, _, flags,_, _, _, wasEarnedByMe, earnedBy = GetAchievementInfo(categoryID, i)
-			if achievementID then
-				ScanSingleAchievement(achievementID, achCompleted, month, day, year, flags, wasEarnedByMe)
-
-				-- track previous steps of a progressive achievements
-				prevID = GetPreviousAchievement(achievementID)
-
-				while type(prevID) ~= "nil" do
-					achievementID, _, _, achCompleted, month, day, year, _, flags,_, _, _, wasEarnedByMe, earnedBy = GetAchievementInfo(prevID)
-					if not achievementID then break end	-- exit the loop if id is invalid
-					
-					ScanSingleAchievement(achievementID, achCompleted, month, day, year, flags, wasEarnedByMe)
-					prevID = GetPreviousAchievement(achievementID)
-				end
-			end
+	local function ProcessBatch()
+		local endIdx = math.min(idx + CATEGORIES_PER_FRAME - 1, #cats)
+		while idx <= endIdx do
+			ScanCategory(cats[idx])
+			idx = idx + 1
+		end
+		if idx <= #cats then
+			C_Timer.After(0, ProcessBatch)
 		end
 	end
+
+	ProcessBatch()
 end
 
 local function ScanProgress()

--- a/DataStore_Achievements/DataStore_Achievements.toc
+++ b/DataStore_Achievements/DataStore_Achievements.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 50501
+## Interface: 120000, 50501, 120005
 ## Title: DataStore_Achievements
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 


### PR DESCRIPTION
## Summary
- `ScanAllAchievements()` errors with `script ran too long` on PLAYER_ALIVE in 12.0+. There are now 170+ categories and the synchronous double-loop (with `GetPreviousAchievement()` chains on top) exceeds WoW's per-script execution budget.
- Extract the per-category work into a `ScanCategory` helper, then drive it from `ProcessBatch` which scans 15 categories per frame and re-schedules itself via `C_Timer.After(0, ...)` until done.
- Declare 12.0.5 in toc.

## Repro
```
1x DataStore_Achievements/DataStore_Achievements.lua:186: script ran too long
[DataStore_Achievements/DataStore_Achievements.lua]:186: in function <...DataStore_Achievements.lua:171>
[DataStore_Achievements/DataStore_Achievements.lua]:506: in function 'callback'
[AddonFactory/Core/Addon.lua]:17: in function <AddonFactory/Core/Addon.lua:13>
```

Locals showed iteration was at category 23 of 169 — the script timeout fires well before the scan is half done.

## Behaviour change
- The scan is now asynchronous. `thisCharacter.Partial` is populated incrementally over ~12 frames after PLAYER_ALIVE instead of being fully ready when `ScanAllAchievements()` returns. Reads during this window will see partial data, but that's strictly better than the previous behaviour where the scan aborted mid-way.
- `ScanProgress()` still runs immediately (it doesn't depend on Partial being complete).

## Test plan
- [ ] Log in fresh on 12.0.5 — no `script ran too long` error.
- [ ] After ~1s, `/dump DataStore:GetAchievementInfo(...)` returns expected results across categories that previously were silently dropped (anything past category ~22).
- [ ] Achievement-earned events still update incrementally (they go through `ACHIEVEMENT_EARNED`, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)